### PR TITLE
Cambiado process() por private_core()

### DIFF
--- a/controller/tarifas_proveedor.php
+++ b/controller/tarifas_proveedor.php
@@ -41,7 +41,7 @@ class tarifas_proveedor extends fs_controller {
         parent::__construct(__CLASS__, 'Tarifas de proveedor', 'compras', FALSE, FALSE);
     }
 
-    protected function process() {
+    protected function private_core() {
         
         $this->offset = 0;
         $this->articulo_s = FALSE;


### PR DESCRIPTION
La función process() está obsoleta.